### PR TITLE
City Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
+    "react-hammerjs": "^1.0.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5",

--- a/src/App.css
+++ b/src/App.css
@@ -214,6 +214,30 @@ City Profile Card
     width: 70%;
 }
 
+.navArrowLeft {
+    position: absolute;
+    color: white;
+    fill: white;
+    top: 50%;
+    left: 2%;
+    transform: translateY(-50%);
+    z-index: 2;
+    width: 50px !important;
+    height: 50px !important;
+}
+
+.navArrowRight {
+    position: absolute;
+    color: white;
+    fill: white;
+    top: 50%;
+    right: 2%;
+    transform: translateY(-50%);
+    z-index: 2;
+    width: 50px !important;
+    height: 50px !important;
+}
+
 canvas {
     display: inline-block;
     vertical-align: middle;

--- a/src/App.css
+++ b/src/App.css
@@ -224,6 +224,7 @@ City Profile Card
     z-index: 2;
     width: 50px !important;
     height: 50px !important;
+    cursor: pointer;
 }
 
 .navArrowRight {
@@ -236,6 +237,7 @@ City Profile Card
     z-index: 2;
     width: 50px !important;
     height: 50px !important;
+    cursor: pointer;
 }
 
 canvas {

--- a/src/components/CityProfileCard.js
+++ b/src/components/CityProfileCard.js
@@ -9,6 +9,9 @@ import Grid from '@material-ui/core/Grid/Grid';
 import Paper from '@material-ui/core/Paper/Paper';
 import Slide from '@material-ui/core/Slide/Slide';
 import withStyles from '@material-ui/core/styles/withStyles';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
 
 import CityStatsCard from '../components/CityStatsCard';
 import MapLegend from '../components/MapLegend';
@@ -30,19 +33,29 @@ const styles = () => ({
     margin: 0,
     backgroundColor: '#F4F4F4',
     boxShadow: 'none'
-  },
+  }
 
 });
 
 class CityProfileCard extends Component {
   state = {
     cityData: null,
+    prevCityData: null,
+    nextCityData: null,
     checked: false,
   };
 
+  componentDidUpdate() {
+    const { match: { params: { cityState } } } = this.props;
+    if(cityState.toLowerCase() !== this.state.cityData.cityName.toLowerCase() + this.state.cityData.state.toLowerCase()) {
+      this.getCityData(cityState);
+      this.initializeSlide();
+    }
+  }
+
   componentDidMount() {
-    const { match: { params: { cityName } } } = this.props;
-    this.getCityData(cityName);
+    const { match: { params: { cityState } } } = this.props;
+    this.getCityData(cityState);
     this.initializeSlide();
   }
 
@@ -50,14 +63,21 @@ class CityProfileCard extends Component {
     this.setState({ checked: true });
   };
 
-  getCityData = cityName => {
+  getCityData = cityState => {
+    const cityData = data.find(obj => obj.cityName.toLowerCase() + obj.state.toLowerCase() === cityState.toLowerCase());
+    const prevCityData = data.find(obj => obj.ranking === cityData.ranking - 1);
+    const nextCityData = data.find(obj => obj.ranking === cityData.ranking + 1);
     this.setState({
-      cityData: data.find(obj => obj.cityName.toLowerCase() === cityName.toLowerCase()),
+      cityData,
+      prevCityData,
+      nextCityData
     });
   };
 
   render() {
     const { cityData } = this.state;
+    const { prevCityData } = this.state;
+    const { nextCityData } = this.state;
     const { classes } = this.props;
 
 
@@ -73,12 +93,20 @@ class CityProfileCard extends Component {
         <Slide direction="right" in={this.state.checked} mountOnEnter unmountOnExit>
           <Paper className={classes.paper}>
             <div className="headerContainer">
+              {prevCityData != null ? 
+                <KeyboardArrowLeft 
+                  className="navArrowLeft" 
+                  onClick={() => this.props.history.push(`/city/${prevCityData.cityName}${prevCityData.state}`)} /> : null }
               <img src={require('../' + cityData.headerImage)} alt={`${cityData.cityName} Header`}
                    style={{ width: '100%', height: '100%', filter: 'brightness(60%)' }}/>
               <div className="alignIconHeader">
                 <RankingIcon cityData={cityData}/>
                 <h1 className="cityHeader">{cityData.cityName}</h1>
               </div>
+              {nextCityData != null ? 
+                <KeyboardArrowRight 
+                  className="navArrowRight"
+                  onClick={() => this.props.history.push(`/city/${nextCityData.cityName}${nextCityData.state}`)}/> : null }
             </div>
             <Grid container className="cardGrid">
               <Grid item md={6} sm={12} xs={12} className="gridItem">

--- a/src/components/CityProfileCard.js
+++ b/src/components/CityProfileCard.js
@@ -12,6 +12,7 @@ import withStyles from '@material-ui/core/styles/withStyles';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 
+import Hammer from 'react-hammerjs';
 
 import CityStatsCard from '../components/CityStatsCard';
 import MapLegend from '../components/MapLegend';
@@ -45,15 +46,8 @@ class CityProfileCard extends Component {
     checked: false,
   };
 
-  componentDidUpdate() {
-    const { match: { params: { cityState } } } = this.props;
-    if(cityState.toLowerCase() !== this.state.cityData.cityName.toLowerCase() + this.state.cityData.state.toLowerCase()) {
-      this.getCityData(cityState);
-      this.initializeSlide();
-    }
-  }
-
   componentDidMount() {
+    console.log('mount');
     const { match: { params: { cityState } } } = this.props;
     this.getCityData(cityState);
     this.initializeSlide();
@@ -74,6 +68,36 @@ class CityProfileCard extends Component {
     });
   };
 
+  handleSwipe = (e) => {
+    const { prevCityData } = this.state;
+    const { nextCityData } = this.state;
+    //swipe right
+    if(e.direction === 4 && this.state.prevCityData) {
+      this.handleNavBackward();
+    }
+    //swipe left
+    if(e.direction === 2 && this.state.nextCityData) {
+      this.handleNavForward();
+    }
+  }
+
+  handleNavForward = () => {
+    console.log('navForward');
+    const { nextCityData } = this.state;
+    const nextCityState = nextCityData.cityName + nextCityData.state;
+    this.props.history.push(`/city/${nextCityState}`);
+    this.getCityData(nextCityState);
+    this.initializeSlide();
+  }
+
+  handleNavBackward = () => {
+    const { prevCityData } = this.state;
+    const prevCityState = prevCityData.cityName + prevCityData.state;
+    this.props.history.push(`/city/${prevCityState}`);
+    this.getCityData(prevCityState);
+    this.initializeSlide();
+  }
+
   render() {
     const { cityData } = this.state;
     const { prevCityData } = this.state;
@@ -89,50 +113,50 @@ class CityProfileCard extends Component {
     }
 
     return (
-      <div>
-        <Slide direction="right" in={this.state.checked} mountOnEnter unmountOnExit>
-          <Paper className={classes.paper}>
-            <div className="headerContainer">
-              {prevCityData != null ? 
-                <KeyboardArrowLeft 
-                  className="navArrowLeft" 
-                  onClick={() => this.props.history.push(`/city/${prevCityData.cityName}${prevCityData.state}`)} /> : null }
-              <img src={require('../' + cityData.headerImage)} alt={`${cityData.cityName} Header`}
-                   style={{ width: '100%', height: '100%', filter: 'brightness(60%)' }}/>
-              <div className="alignIconHeader">
-                <RankingIcon cityData={cityData}/>
-                <h1 className="cityHeader">{cityData.cityName}</h1>
+      <Hammer key={cityData.key} onSwipe={this.handleSwipe}>
+        <div>
+          <Slide direction="right" in={this.state.checked} mountOnEnter unmountOnExit>
+            <Paper className={classes.paper}>
+              <div className="headerContainer">
+                {prevCityData != null ? 
+                  <KeyboardArrowLeft 
+                    className="navArrowLeft" 
+                    onClick={this.handleNavBackward} /> : null }
+                <img src={require('../' + cityData.headerImage)} alt={`${cityData.cityName} Header`}
+                    style={{ width: '100%', height: '100%', filter: 'brightness(60%)' }}/>
+                <div className="alignIconHeader">
+                  <RankingIcon cityData={cityData}/>
+                  <h1 className="cityHeader">{cityData.cityName}</h1>
+                </div>
+                {nextCityData != null ? 
+                  <KeyboardArrowRight 
+                    className="navArrowRight"
+                    onClick={this.handleNavForward}/> : null }
               </div>
-              {nextCityData != null ? 
-                <KeyboardArrowRight 
-                  className="navArrowRight"
-                  onClick={() => this.props.history.push(`/city/${nextCityData.cityName}${nextCityData.state}`)}/> : null }
-            </div>
-            <Grid container className="cardGrid">
-              <Grid item md={6} sm={12} xs={12} className="gridItem">
-                <Card className={classes.root}>
-                  <div>
-                    <CardContent style={{ padding: 0 }}>
-                    </CardContent>
-                    <CardMedia
-                      component="img"
-                      className="media"
-                      image={require('../' + cityData.mapImage)}
-                    />
-                    <MapLegend/>
-                  </div>
+              <Grid container className="cardGrid">
+                <Grid item md={6} sm={12} xs={12} className="gridItem">
+                  <Card className={classes.root}>
+                    <div>
+                      <CardContent style={{ padding: 0 }}>
+                      </CardContent>
+                      <CardMedia
+                        component="img"
+                        className="media"
+                        image={require('../' + cityData.mapImage)}
+                      />
+                      <MapLegend/>
+                    </div>
 
-                </Card>
+                  </Card>
+                </Grid>
+                <Grid item md={6} sm={12} xs={12} className="gridItem">
+                  <CityStatsCard data={cityData}/>
+                </Grid>
               </Grid>
-              <Grid item md={6} sm={12} xs={12} className="gridItem">
-                <CityStatsCard data={cityData}/>
-              </Grid>
-            </Grid>
-          </Paper>
-        </Slide>
-
-
-      </div>
+            </Paper>
+          </Slide>
+        </div>
+      </Hammer>
     );
   }
 }

--- a/src/components/CityProfileCard.js
+++ b/src/components/CityProfileCard.js
@@ -87,7 +87,6 @@ class CityProfileCard extends Component {
     const nextCityState = nextCityData.cityName + nextCityData.state;
     this.props.history.push(`/city/${nextCityState}`);
     this.getCityData(nextCityState);
-    this.initializeSlide();
   }
 
   handleNavBackward = () => {
@@ -95,7 +94,6 @@ class CityProfileCard extends Component {
     const prevCityState = prevCityData.cityName + prevCityData.state;
     this.props.history.push(`/city/${prevCityState}`);
     this.getCityData(prevCityState);
-    this.initializeSlide();
   }
 
   render() {

--- a/src/components/CityProfileCard.js
+++ b/src/components/CityProfileCard.js
@@ -47,7 +47,6 @@ class CityProfileCard extends Component {
   };
 
   componentDidMount() {
-    console.log('mount');
     const { match: { params: { cityState } } } = this.props;
     this.getCityData(cityState);
     this.initializeSlide();
@@ -82,7 +81,6 @@ class CityProfileCard extends Component {
   }
 
   handleNavForward = () => {
-    console.log('navForward');
     const { nextCityData } = this.state;
     const nextCityState = nextCityData.cityName + nextCityData.state;
     this.props.history.push(`/city/${nextCityState}`);

--- a/src/components/CityRankingTable.js
+++ b/src/components/CityRankingTable.js
@@ -44,7 +44,7 @@ class CityRankingTable extends Component {
             <div style={{ padding: '5px 0' }}>
               {data.sort((a, b) => a.ranking - b.ranking).map(city => {
                 return (<Card className="cityRankingCard" key={city.ranking}
-                              onClick={() => this.props.history.push(`/city/${city.cityName}`)}>
+                              onClick={() => this.props.history.push(`/city/${city.cityName}${city.state}`)}>
                   <CardContent>
                     <div className="cardBody">
                       <img className="cityTableImage" src={require('../' + city.headerImage)}

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -12,7 +12,7 @@ const Main = () => (
     <Switch>
       <Route exact path="/" component={Splash}/>
       <Route exact path="/rankings" component={CityRankingTable}/>
-      <Route exact path="/city/:cityName" component={CityProfileCard}/>
+      <Route exact path="/city/:cityState" component={CityProfileCard}/>
       <Route exact path="/about-us" component={AboutUs}/>
       <Route exact path="/methodology" component={Methodology}/>
     </Switch>

--- a/src/components/RankingIcon.js
+++ b/src/components/RankingIcon.js
@@ -1,16 +1,13 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 
 
-class RankingIcon extends PureComponent {
+class RankingIcon extends Component {
   constructor(props) {
     super(props);
     this.canvas = React.createRef();
   }
 
-  componentDidUpdate() {
-    const { cityData } = this.props;
-    this.updateCanvas(cityData);
-  }
+
 
   componentDidMount() {
     const { cityData } = this.props;

--- a/src/components/RankingIcon.js
+++ b/src/components/RankingIcon.js
@@ -1,10 +1,15 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 
 
-class RankingIcon extends Component {
+class RankingIcon extends PureComponent {
   constructor(props) {
     super(props);
     this.canvas = React.createRef();
+  }
+
+  componentDidUpdate() {
+    const { cityData } = this.props;
+    this.updateCanvas(cityData);
   }
 
   componentDidMount() {
@@ -17,6 +22,7 @@ class RankingIcon extends Component {
     const height = this.canvas.current.height;
     const width = this.canvas.current.width;
 
+    ctx.clearRect(0, 0, width, height);
     // Canvas Styling
     ctx.font = cityData.ranking > 10 ? 'bold 25px Open Sans' : 'bold 30px Open Sans';
     ctx.fillStyle = 'blue';

--- a/src/components/RankingIcon.js
+++ b/src/components/RankingIcon.js
@@ -10,8 +10,6 @@ class RankingIcon extends Component {
   componentDidMount() {
     const { cityData } = this.props;
     this.updateCanvas(cityData);
-
-
   }
 
   updateCanvas(cityData) {


### PR DESCRIPTION
Adds ability to navigate between next and previous cities in ranking order by tapping arrows on either side of city name, or by swiping left/right on a mobile device. 

Probably need to remove animation, or update animate to slide left/right depending on if next or previous was selected