### PR TITLE
Rename quality trend to error rate

### DIFF
--- a/src/components/CityStatsCard.js
+++ b/src/components/CityStatsCard.js
@@ -37,7 +37,7 @@ const CityStatsCard = props => {
                     </object>
                     <div>
                         <h2 style={{margin: 0, display: 'inline'}}>{flagTrend.toFixed(2)}%</h2>
-                        <p>Quality Trend (vs. 2018)</p>
+                        <p>Error Rate (vs. 2018)</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR just rename "Quality Trend(vs. 2018)" in the Quick Stats to "Error Rate (vs. 2018).