### PR TITLE
Minor text updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-measure": "^2.3.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "1.1.5",
+    "react-scripts": "2.0.5",
     "react-svg-piechart": "^2.1.1",
     "react-swipeable-views": "^0.13.0"
   },
@@ -40,5 +40,11 @@
   "devDependencies": {
     "gh-pages": "^2.0.0"
   },
-  "homepage": "https://www.osmquality.io"
+  "homepage": "https://www.osmquality.io",
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/components/CityProfileCard.js
+++ b/src/components/CityProfileCard.js
@@ -204,7 +204,7 @@ class CityProfileCard extends Component {
                         <Grid item style={{display: 'flex', flex: '2 0 0%'}}>
                           <div className="cardHeaderContainer" style={{width: '100%'}}>
                             <h3 className="cardHeader" style={{marginLeft: 0}}>
-                              MQM Error Rate
+                              MQM Results
                             </h3>
                             {/*blah*/}
                           </div>
@@ -212,7 +212,7 @@ class CityProfileCard extends Component {
                         </Grid>
                         {/* Weights */}
                         <Grid item style={{display: 'flex', flex: '1 0 0%'}}>
-                          <div style={{margin: 'auto 8px auto 0px'}}>Weight Error Rate by: </div>
+                          <div style={{margin: 'auto 8px auto 0px'}}>Weight MQM Results by: </div>
                             <MuiThemeProvider theme={theme}>
                               <FormControl component="fieldset">
                                 <RadioGroup
@@ -250,7 +250,7 @@ class CityProfileCard extends Component {
                         {/*Legend*/}
                         <Grid item container justify='space-between' style={{display: 'flex', flex: '2 0 0%'}}>
                           <MapLegend/>
-                          <div style={{margin: 'auto 0px', height: 45}}>{this.context.style === 'wfh' ? 'Default MQM Error Rate' : this.context.style === 'ppl' ? 'Weighted by Population' : 'Weighted by Car Ownership'}</div>
+                          <div style={{margin: 'auto 0px', height: 45}}>{this.context.style === 'wfh' ? 'Default MQM Results' : this.context.style === 'ppl' ? 'Weighted by Population' : 'Weighted by Car Ownership'}</div>
                         </Grid>
                       </Grid>
                     </CardContent>


### PR DESCRIPTION
This PR has some minor updates to the text. Specifically:

MQM Error Rate -> MQM Results. 
Weight Error Rate by -> Weight MQM Results by 
Default MQM Error Rate -> Default MQM Results

Looks like this:
![image](https://user-images.githubusercontent.com/12106730/64299962-fa399100-cf2f-11e9-9451-6adfd29c340e.png)

In addition, I updated the version of a package and added a the default `browserslist` to package.json so that `npm run deploy` would work, since I ran into some problems around that last time I deployed.